### PR TITLE
Add support for rekeying all paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 result*
+/.envrc

--- a/shell.nix
+++ b/shell.nix
@@ -11,4 +11,4 @@ let
           || baseNameOf path != "result") ./.;
     };
 in
-flake.shellNix
+flake.shellNix.default

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,6 +151,12 @@ struct Config {
     root: PathBuf,
 }
 
+const MATCH_OPTS: glob::MatchOptions = glob::MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
+
 /// Run `agenix`.
 pub fn run() -> Result<()> {
     let opts = Agenix::parse();
@@ -220,7 +226,7 @@ pub fn run() -> Result<()> {
     if opts.rekey && opts.path.is_none() {
         let mut paths = Vec::new();
         for pathspec in &conf.agenix.paths {
-            for path in glob::glob(&pathspec.glob)
+            for path in glob::glob_with(&pathspec.glob, MATCH_OPTS)
                 .wrap_err_with(|| format!("Failed to match glob pattern '{}'", &pathspec.glob))?
             {
                 let path = path.wrap_err_with(|| {
@@ -519,7 +525,7 @@ fn get_recipients_from_config(
             );
         }
 
-        if glob.matches(&target.display().to_string()) {
+        if glob.matches_path_with(&target, MATCH_OPTS) {
             let identities = {
                 let mut ids = path.identities.clone();
 


### PR DESCRIPTION
Fixes #6 by adding a `--rekey-all` flag. And contains a change to shell.nix to make lorri + direnv (mostly) work.

For the most part, I just moved the decrypt, edit and encrypt process into its own function, calling it for all files matched by any of the glob-patterns in the config, when `--rekey-all` is specified.

The second commit is a change to the `shell.nix` I needed to get `lorri shell` to evaluate successfully. Sadly, lorri does not automatically re-evaluate when the flake's `devShell` changes. No idea how to get that to work. `nix-shell` and `nix develop` should still work as before. (I also added `.envrc` to the `.gitignore` to keep it out of the repo.)

Note that I am quite new to rust, so I might have done something dumb or very un-idiomatic.