### PR TITLE
Config validation and warning for path matched by multiple patterns

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -500,6 +500,7 @@ fn get_recipients_from_config(
     target: &Path,
 ) -> Result<Vec<Box<dyn age::Recipient>>> {
     let mut recipients: Vec<Box<dyn age::Recipient>> = Vec::new();
+    let mut matches = 0;
 
     for path in &conf.agenix.paths {
         if path.identities.is_empty() && path.groups.is_empty() {
@@ -559,8 +560,20 @@ fn get_recipients_from_config(
                 }
             }
 
-            break;
+            matches += 1;
         }
+    }
+
+    if matches == 0 {
+        warn!(
+            "Path '{}' is not matched by any configured glob pattern",
+            &target.display()
+        );
+    } else if 1 < matches {
+        warn!(
+            "Path '{}' is matched by more than one configured glob pattern",
+            &target.display()
+        );
     }
 
     Ok(recipients)


### PR DESCRIPTION
Adds a `--validate-config` flag that does some basic validation of the config. It checks, that
- all keys of identities are parseable,
- no groups are empty,
- all identities referenced in groups exist,
- no file exists, that is matched by multiple glob patterns from the config,
- all groups associated with paths exist,
- all identities associated with paths exist or are parseable keys.

Also fixes #8  by adding a warning message when a path is matched by multiple glob patterns in the config file.

(Based on #7 as I assume that'll get merged for the most part.)