### PR TITLE
WiP absolute paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,7 +350,10 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    let relative_path = current_path.strip_prefix(&conf.root).unwrap_or(&env::current_dir()?).join(path);
+    let relative_path = current_path
+        .strip_prefix(&conf.root)
+        .unwrap_or(&env::current_dir()?)
+        .join(path);
     let recipients = self::get_recipients_from_config(&conf, &relative_path)
         .wrap_err("Failed to get recipients from config file")?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,10 +350,7 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    let relative_path = match current_path.strip_prefix(&conf.root) {
-		Ok(stripped) => stripped.join(path),
-		Err(_) => env::current_dir()?.join(path),
-	};
+    let relative_path = current_path.strip_prefix(&conf.root).unwrap_or(&env::current_dir()?).join(path);
     let recipients = self::get_recipients_from_config(&conf, &relative_path)
         .wrap_err("Failed to get recipients from config file")?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,7 +352,7 @@ where
     let path = path.as_ref();
     let relative_path = match current_path.strip_prefix(&conf.root) {
 		Ok(stripped) => stripped.join(path),
-		Err(_) => path.to_path_buf(),
+		Err(_) => env::current_dir()?.join(path),
 	};
     let recipients = self::get_recipients_from_config(&conf, &relative_path)
         .wrap_err("Failed to get recipients from config file")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,7 +352,7 @@ where
     let path = path.as_ref();
     let relative_path = current_path
         .strip_prefix(&conf.root)
-        .unwrap_or(&env::current_dir()?)
+        .unwrap_or(&env::current_dir().wrap_err("Failed to get current directory")?)
         .join(path);
     let recipients = self::get_recipients_from_config(&conf, &relative_path)
         .wrap_err("Failed to get recipients from config file")?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -610,18 +610,6 @@ fn get_recipients_from_config(
         let glob = glob::Pattern::new(&path.glob)
             .wrap_err_with(|| format!("Failed to construct glob pattern from '{}'", &path.glob))?;
 
-        // Roundabout way of checking whether or not a path is trying to escape
-        // the configured directory.
-        if self::normalize_path(&conf.root.join(&target))
-            .strip_prefix(&conf.root)
-            .is_err()
-        {
-            bail!(
-                "Path '{}' tried to escape the agenix config root",
-                &target.display()
-            );
-        }
-
         if glob.matches_path_with(&target, MATCH_OPTS) {
             let identities = {
                 let mut ids = path.identities.clone();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -350,16 +350,10 @@ where
     P: AsRef<Path>,
 {
     let path = path.as_ref();
-    let relative_path = current_path
-        .strip_prefix(&conf.root)
-        .wrap_err_with(|| {
-            format!(
-                "Failed to strip prefix '{}' of '{}'",
-                &conf.root.display(),
-                &current_path.display()
-            )
-        })?
-        .join(&path);
+    let relative_path = match current_path.strip_prefix(&conf.root) {
+		Ok(stripped) => stripped.join(path),
+		Err(_) => path.to_path_buf(),
+	};
     let recipients = self::get_recipients_from_config(&conf, &relative_path)
         .wrap_err("Failed to get recipients from config file")?;
 


### PR DESCRIPTION
Hi! This works for my usage (one key matching `**`), but I can't seem to get it to match actual absolute paths. I'm not certain where this comes from, maybe the `normalize_path` function? If you could take a look I'd be most appreciative. Thanks!